### PR TITLE
Module 7 grpc and protobuf

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,6 +22,12 @@
         </dependency>
         <dependency>
             <groupId>github.com.hukuta94.delivery</groupId>
+            <artifactId>delivery-core-test-fixtures</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>github.com.hukuta94.delivery</groupId>
             <artifactId>delivery-infrastructure</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
@@ -31,6 +37,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/Configuration.kt
+++ b/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/Configuration.kt
@@ -16,5 +16,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc
     CourierConfiguration::class,
     DomainServiceConfiguration::class,
     SchedulerConfiguration::class,
+    PortConfiguration::class,
 )
 open class Configuration

--- a/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/PortConfiguration.kt
+++ b/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/PortConfiguration.kt
@@ -1,11 +1,34 @@
 package github.com.hukuta94.delivery.api.startup.configuration
 
 import github.com.hukuta94.delivery.infrastructure.adapter.grpc.GeoServiceGrpcClient
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import javax.annotation.PreDestroy
 
 @Configuration
 open class PortConfiguration {
+
+    private lateinit var geoServiceGrpChannel: ManagedChannel
+
     @Bean
-    open fun getLocationPort() = GeoServiceGrpcClient()
+    open fun geoServiceGrpChannelBean(): ManagedChannel {
+        return ManagedChannelBuilder.forAddress("localhost", 8084)
+            .usePlaintext() // disable SSL/TLS
+            .build()
+    }
+
+    @PreDestroy
+    fun geoServiceGrpChannelShutDown() {
+        if (::geoServiceGrpChannel.isInitialized) {
+            geoServiceGrpChannel.shutdown()
+            println("gRPC channel shutdown")
+        }
+    }
+
+    @Bean
+    open fun getLocationPort(
+        grpcChannel: ManagedChannel,
+    ) = GeoServiceGrpcClient(grpcChannel)
 }

--- a/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/PortConfiguration.kt
+++ b/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/PortConfiguration.kt
@@ -1,0 +1,11 @@
+package github.com.hukuta94.delivery.api.startup.configuration
+
+import github.com.hukuta94.delivery.infrastructure.adapter.grpc.GeoServiceGrpcClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class PortConfiguration {
+    @Bean
+    open fun getLocationPort() = GeoServiceGrpcClient()
+}

--- a/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/order/OrderUseCaseConfiguration.kt
+++ b/api/src/main/kotlin/github/com/hukuta94/delivery/api/startup/configuration/order/OrderUseCaseConfiguration.kt
@@ -5,6 +5,7 @@ import github.com.hukuta94.delivery.core.application.usecase.order.command.impl.
 import github.com.hukuta94.delivery.core.application.usecase.order.query.impl.GetNotCompletedOrdersQueryImpl
 import github.com.hukuta94.delivery.core.domain.service.DispatchService
 import github.com.hukuta94.delivery.core.port.CourierRepository
+import github.com.hukuta94.delivery.core.port.GetLocationPort
 import github.com.hukuta94.delivery.core.port.OrderRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -14,9 +15,11 @@ open class OrderUseCaseConfiguration {
 
     @Bean
     open fun createOrderCommand(
-        orderRepository: OrderRepository
+        orderRepository: OrderRepository,
+        getLocationPort: GetLocationPort,
     ) = CreateOrderCommandImpl(
-        orderRepository = orderRepository
+        orderRepository = orderRepository,
+        getLocationPort = getLocationPort,
     )
 
     @Bean

--- a/core/impl/src/main/kotlin/github/com/hukuta94/delivery/core/application/usecase/order/command/impl/CreateOrderCommandImpl.kt
+++ b/core/impl/src/main/kotlin/github/com/hukuta94/delivery/core/application/usecase/order/command/impl/CreateOrderCommandImpl.kt
@@ -4,22 +4,23 @@ import github.com.hukuta94.delivery.core.application.usecase.courier.command.Mov
 import github.com.hukuta94.delivery.core.application.usecase.order.command.Command
 import github.com.hukuta94.delivery.core.application.usecase.order.command.CreateOrderCommand
 import github.com.hukuta94.delivery.core.domain.order.Order
-import github.com.hukuta94.delivery.core.domain.sharedkernel.Location
+import github.com.hukuta94.delivery.core.port.GetLocationPort
 import github.com.hukuta94.delivery.core.port.OrderRepository
 import org.slf4j.LoggerFactory
 
 class CreateOrderCommandImpl(
-    private val orderRepository: OrderRepository
+    private val orderRepository: OrderRepository,
+    private val getLocationPort: GetLocationPort,
 ) : CreateOrderCommand {
     override fun execute(command: Command) {
         LOG.info("Try to create new order with basket id: ${command.basketId}")
 
-        orderRepository.add(
-            Order.create(
-                id = command.basketId,
-                location = Location.random(),
-            )
+        val newOrder = Order.create(
+            id = command.basketId,
+            location = getLocationPort.getFromStreet(command.street),
         )
+
+        orderRepository.add(newOrder)
     }
 
     companion object {

--- a/core/impl/src/main/kotlin/github/com/hukuta94/delivery/core/port/GetLocationPort.kt
+++ b/core/impl/src/main/kotlin/github/com/hukuta94/delivery/core/port/GetLocationPort.kt
@@ -1,0 +1,12 @@
+package github.com.hukuta94.delivery.core.port
+
+import github.com.hukuta94.delivery.core.domain.sharedkernel.Location
+
+/**
+ * Port of application layer to get [Location] value object by different ways.
+ * For example from street [String]
+ */
+interface GetLocationPort {
+
+    fun getFromStreet(street: String): Location
+}

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -14,6 +14,24 @@
     <artifactId>delivery-infrastructure</artifactId>
     <packaging>jar</packaging>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
+    <properties>
+        <grpc.version>1.58.0</grpc.version>
+        <protobuf.version>3.23.4</protobuf.version>
+        <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
+        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>github.com.hukuta94.delivery</groupId>
@@ -26,5 +44,60 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- gRPC -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
+        <!-- Java 9+ compatibility - Do NOT update to 2.0.0 -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${protobuf-plugin.version}</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/infrastructure/src/main/kotlin/github/com/hukuta94/delivery/infrastructure/adapter/grpc/GeoServiceGrpcClient.kt
+++ b/infrastructure/src/main/kotlin/github/com/hukuta94/delivery/infrastructure/adapter/grpc/GeoServiceGrpcClient.kt
@@ -3,25 +3,20 @@ package github.com.hukuta94.delivery.infrastructure.adapter.grpc
 import github.com.hukuta94.delivery.core.domain.sharedkernel.Location
 import github.com.hukuta94.delivery.core.port.GetLocationPort
 import github.com.hukuta94.delivery.infrastructure.adapter.grpc.GeoGrpc.newBlockingStub
-import io.grpc.ManagedChannelBuilder
+import io.grpc.ManagedChannel
 
-class GeoServiceGrpcClient: GeoGrpc.GeoImplBase(), GetLocationPort {
+class GeoServiceGrpcClient(
+    private val managedChannel: ManagedChannel,
+): GeoGrpc.GeoImplBase(), GetLocationPort {
 
     override fun getFromStreet(street: String): Location {
-        //TODO конфигурацию адреса и порта можно вынести в конфиг
-        val channel = ManagedChannelBuilder.forAddress("localhost", 8084)
-            .usePlaintext() // disable SSL/TLS
-            .build()
-
-        val stub = newBlockingStub(channel)
+        val stub = newBlockingStub(managedChannel)
 
         val request = GetGeolocationRequest.newBuilder()
             .setStreet(street)
             .build()
 
         val response = stub.getGeolocation(request)
-
-        channel.shutdown()
 
         return Location(
             abscissa = response.location.x,

--- a/infrastructure/src/main/kotlin/github/com/hukuta94/delivery/infrastructure/adapter/grpc/GeoServiceGrpcClient.kt
+++ b/infrastructure/src/main/kotlin/github/com/hukuta94/delivery/infrastructure/adapter/grpc/GeoServiceGrpcClient.kt
@@ -1,0 +1,31 @@
+package github.com.hukuta94.delivery.infrastructure.adapter.grpc
+
+import github.com.hukuta94.delivery.core.domain.sharedkernel.Location
+import github.com.hukuta94.delivery.core.port.GetLocationPort
+import github.com.hukuta94.delivery.infrastructure.adapter.grpc.GeoGrpc.newBlockingStub
+import io.grpc.ManagedChannelBuilder
+
+class GeoServiceGrpcClient: GeoGrpc.GeoImplBase(), GetLocationPort {
+
+    override fun getFromStreet(street: String): Location {
+        //TODO конфигурацию адреса и порта можно вынести в конфиг
+        val channel = ManagedChannelBuilder.forAddress("localhost", 8084)
+            .usePlaintext() // disable SSL/TLS
+            .build()
+
+        val stub = newBlockingStub(channel)
+
+        val request = GetGeolocationRequest.newBuilder()
+            .setStreet(street)
+            .build()
+
+        val response = stub.getGeolocation(request)
+
+        channel.shutdown()
+
+        return Location(
+            abscissa = response.location.x,
+            ordinate = response.location.y,
+        )
+    }
+}

--- a/infrastructure/src/main/proto/GeoServiceContract.proto
+++ b/infrastructure/src/main/proto/GeoServiceContract.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+option csharp_namespace = "GeoApp.Api";
+option java_multiple_files = true;
+option java_package = "github.com.hukuta94.delivery.infrastructure.adapter.grpc";
+option java_outer_classname = "GeoServiceProtos";
+
+// The Geo service definition.
+service Geo {
+
+  // Get Geolocation
+  rpc GetGeolocation (GetGeolocationRequest) returns (GetGeolocationReply);
+}
+
+// Request
+message GetGeolocationRequest {
+  string Street = 1;
+}
+
+// Response
+message GetGeolocationReply {
+  Location Location = 1;
+}
+
+// Geolocation
+message Location {
+  int32 x = 1;
+  int32 y = 2;
+}
+
+message ErrorResponse {
+  string text = 1;
+}


### PR DESCRIPTION
В целом код выглядит рабочим. Удалось сгенерировать java классы по .proto контракту внешнего Geo сервиса.

Проблема, с которой столкнулся:
В докере Geo сервис использует HTTP/1.1: 

geo-1 | HTTP/2 is not enabled for 0.0.0.0:8084. The endpoint is configured to use HTTP/1.1 and HTTP/2, but TLS is not enabled. HTTP/2 requires TLS application protocol negotiation. Connections to this endpoint will use HTTP/1.1.

Мой grpc клиент использует протокол HTTP/2, из-за чего при попытке отправить запрос в Geo сервис получаю ошибку:
io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception: First received frame was not SETTINGS. Hex dump for first 5 bytes: 0000080700

Из альтернативных решений:
Использовать grpc-web. Как вариант можно будет добавить его вторым инфраструктурным адаптером.

UPD
После правки Geo сервиса и настройки его на HTTP/2, мой grpc клиент получил ответ от grpc сервиса Geo!